### PR TITLE
feat(profile): add CDK env vars to profile mod

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -44,12 +44,12 @@ p6df::modules::cdk8s::clones() {
 ######################################################################
 #<
 #
-# Function: words cdk8s $CDK8S_OUTDIR = p6df::modules::cdk8s::profile::mod()
+# Function: words cdk8s $CDK_DEPLOYMENT_ACCOUNT $CDK_DEPLOYMENT_REGION $CDK_DEFAULT_ACCOUNT $CDK_DEFAULT_REGION = p6df::modules::cdk8s::profile::mod()
 #
 #  Returns:
-#	words - cdk8s $CDK8S_OUTDIR
+#	words - cdk8s $CDK_DEPLOYMENT_ACCOUNT $CDK_DEPLOYMENT_REGION $CDK_DEFAULT_ACCOUNT $CDK_DEFAULT_REGION
 #
-#  Environment:	 CDK8S_OUTDIR
+#  Environment:	 CDK_DEPLOYMENT_ACCOUNT CDK_DEPLOYMENT_REGION CDK_DEFAULT_ACCOUNT CDK_DEFAULT_REGION
 #>
 ######################################################################
 p6df::modules::cdk8s::profile::mod() {

--- a/init.zsh
+++ b/init.zsh
@@ -54,6 +54,6 @@ p6df::modules::cdk8s::clones() {
 ######################################################################
 p6df::modules::cdk8s::profile::mod() {
 
-  p6_return_words 'cdk8s' "$"
+  p6_return_words 'cdk8s' '$CDK_DEPLOYMENT_ACCOUNT' '$CDK_DEPLOYMENT_REGION' '$CDK_DEFAULT_ACCOUNT' '$CDK_DEFAULT_REGION'
 }
 


### PR DESCRIPTION
## What
Add CDK environment variables (`$CDK_DEPLOYMENT_ACCOUNT`, `$CDK_DEPLOYMENT_REGION`, `$CDK_DEFAULT_ACCOUNT`, `$CDK_DEFAULT_REGION`) to the `p6df::modules::cdk8s::profile::mod` function.

## Why
The profile mod was returning only the module name with a bare `"$"` placeholder. This populates it with the actual CDK env vars that should be exported/tracked for CDK-based workflows.

## Test plan
- Reviewed diff; change is a one-line string replacement in `init.zsh`
- No functional logic changed, only the return value of the profile mod function

## Dependencies
None