### PR TITLE
feat(cdk8s): simplify profile::mod return value and sort env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ TODO: Add a short summary of this module.
 - `p6df::modules::cdk8s::clones()`
 - `p6df::modules::cdk8s::deps()`
 - `p6df::modules::cdk8s::langs()`
+- `words cdk8s = p6df::modules::cdk8s::profile::mod()`
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -44,12 +44,12 @@ p6df::modules::cdk8s::clones() {
 ######################################################################
 #<
 #
-# Function: words cdk8s $CDK_DEPLOYMENT_ACCOUNT $CDK_DEPLOYMENT_REGION $CDK_DEFAULT_ACCOUNT $CDK_DEFAULT_REGION = p6df::modules::cdk8s::profile::mod()
+# Function: words cdk8s = p6df::modules::cdk8s::profile::mod()
 #
 #  Returns:
-#	words - cdk8s $CDK_DEPLOYMENT_ACCOUNT $CDK_DEPLOYMENT_REGION $CDK_DEFAULT_ACCOUNT $CDK_DEFAULT_REGION
+#	words - cdk8s
 #
-#  Environment:	 CDK_DEPLOYMENT_ACCOUNT CDK_DEPLOYMENT_REGION CDK_DEFAULT_ACCOUNT CDK_DEFAULT_REGION
+#  Environment:	 CDK_DEFAULT_ACCOUNT CDK_DEFAULT_REGION CDK_DEPLOYMENT_ACCOUNT CDK_DEPLOYMENT_REGION
 #>
 ######################################################################
 p6df::modules::cdk8s::profile::mod() {


### PR DESCRIPTION
**What:** Simplify `profile::mod` return signature to `words cdk8s` (removing individual CDK env vars from return), sort environment variable list alphabetically

**Why:** Reduces verbosity in the function signature; env var documentation is sorted for consistency

**Test plan:** Source the module and verify `p6df::modules::cdk8s::profile::mod` still returns the expected prompt context

**Dependencies:** none